### PR TITLE
Added API table and more information on setting up with KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,84 @@ signer-proxy yubihsm -d <device-serial-id> -a <auth-key-id> -p <password> serve
 No additional options and flags for `serve` subcommand.
 
 ## AWS KMS
+### Set Up
+To use the signer-proxy with AWS KMS, you must have an asymmetric key configured for signing transactions. If you don’t have one, follow this [guide](https://aws.amazon.com/blogs/web3/import-ethereum-private-keys-to-aws-kms/).
 
-### serve
+You’ll also need the AWS CLI installed on the device where you plan to run the proxy. Installation instructions can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 
-Starts an AWS KMS-based proxy server that listens for `eth_signTransaction` requests.
+### Configuration
+Wherever you run the proxy, it must be configured with your KMS key. 
 
 ```bash
-signer-proxy aws-kms serve
+aws configure
 ```
 
-Configuration is managed through shared `.aws/config` and `.aws/credentials` files or environment variables:
+Enter the Access Key ID, Secret Access Key and Default region name for an IAM account that has usage permissions for your key. Put the output format as json.
+
+Alternatively, set your environment variables:
 
 ```bash
 export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
 export AWS_REGION=
+```
+
+### serve
+
+Starts an AWS KMS-based proxy server that listens for `eth_signTransaction` requests. By default, it listens on `0.0.0.0:4000`
+
+```bash
+signer-proxy aws-kms serve
+```
+
+### API
+
+
+| Method | Endpoint | Description | Parameters | Body |
+| ---  | --- | --- | --- | --- | 
+| `GET` |    `/ping` | Tests that the server is running | - | - |
+| `POST` | `/key/{key_id}` | Signs a proposed transaction and returns it RLP encoded | `key_id` (string) - key identifier of your Amazon KMS key | ```json{"id": 1,"jsonrpc": "2.0","method": "eth_signTransaction","params": [{"chainId": "{chain_id}","data": "0x","from": "{from_address}","gas": "{gas}","gasPrice": "{gas_price}","nonce": "{nonce}","to": "{to_address}","value": "{value_to_send}"}]}```
+| `GET` | `/key/{key_id}/address` | Returns the wallet address of your KMS key | `key_id` (string) - key identifier of your Amazon KMS key | - | 
+
+
+### Example Requests
+
+#### /key/{key_id}
+_Request:_
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "eth_signTransaction",
+    "params": [
+        {
+            "chainId": 17000,
+            "data": "0x",
+            "from": "0xD0e9d614E8d5C5C3e7F09Dcb31CB3A7552deC836",
+            "gas": "0x7b0c",
+            "gasPrice": "0x1250b1",
+            "nonce": "0x0",
+            "to": "0x75dA2Ff67BE16c30195067b3CD40702E1F6D4EAE",
+            "value": "0x2386f26fc10000"
+        }
+    ]
+}' http://localhost:4000/key/65021b59-0433-47e7-975d-0dcbfe898f9e
+```
+
+_Response:_
+```bash
+{"id":1,"jsonrpc":"2.0","result":"0xf86b80831250b1827b0c9475da2ff67be16c30195067b3cd40702e1f6d4eae872386f26fc10000808284f4a009c813f8739ef99dae0c28109ffa1c167c62ec3f0b4f9027106969e4f1aaf966a02d696fee7ae9547cfa027193ba2ab514c2c71ee0bcd262034355b16b2b319c78"}
+```
+
+#### /key/{key_id}/address
+_Request:_
+```bash
+curl -X GET http://localhost:4000/key/65021b59-0433-47e7-975d-0dcbfe898f9e/address
+```
+
+_Response:_
+```bash
+{"address":"0xD0e9d614E8d5C5C3e7F09Dcb31CB3A7552deC836"}
 ```
 
 ## Authentication and Firewall  
@@ -88,7 +151,7 @@ export AWS_REGION=
 
 ## Using `signer-proxy` with the OP Stack  
 
-To secure the private keys used by [OP Stack Privileged Roles](https://docs.optimism.io/chain/security/privileged-roles) with `signer-proxy`, you **must remove all private keys from environment variables and arguments** passed to any OP Stack services, except for `op-node` (e.g., `op-batcher`, `op-proposer`, `op-challenger`, etc.). Instead, configure the signer address and endpoint as environment variables or arguments as shown below:  
+To secure the private keys used by [OP Stack Privileged Roles](https://docs.optimism.io/chain/security/privileged-roles) with `signer-proxy`, you **must remove all private keys from environment variables and arguments** passed to any OP Stack services (e.g., `op-batcher`, `op-proposer`, `op-challenger`, `op-node` etc.). Instead, configure the signer address and endpoint as environment variables or arguments as shown below:  
 
 ### Environment Variables  
 
@@ -106,6 +169,10 @@ OP_PROPOSER_SIGNER_ENDPOINT=http://127.0.0.1:4000/key/...
 # op-challenger  
 OP_CHALLENGER_SIGNER_ADDRESS=0x...  
 OP_CHALLENGER_SIGNER_ENDPOINT=http://127.0.0.1:4000/key/...  
+
+# op-node
+OP_NODE_SIGNER_ADDRESS=0x... 
+OP_NODE_SIGNER_ENDPOINT=http://127.0.0.1:4000/key/...
 
 # For other services, replace [SERVICE] with the service name:  
 OP_[SERVICE]_SIGNER_ADDRESS=0x...  


### PR DESCRIPTION
- Added some context on how to set up a key in KMS and how to configure this key in the same place as where the proxy-server is running
- Added a table describing the API of the proxy-server and gave some example requests to sign a transaction and get the address of your wallet.
- Removed that OP-Node needed private keys since they now can accept an address and endpoint