### PR TITLE
Sign Blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 axum = { version = "0.7.5", features = ["macros"] }
 tokio = { version = "1.39.3", features = ["rt-multi-thread", "signal"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_with = { version = "3.12.0", features = ["base64"] }
 hex   = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"
 structopt = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 axum = { version = "0.7.5", features = ["macros"] }
 tokio = { version = "1.39.3", features = ["rt-multi-thread", "signal"] }
 serde = { version = "1.0", features = ["derive"] }
+hex   = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"
 structopt = "0.3"
 tracing = "0.1.40"
@@ -26,6 +27,7 @@ strum = { version = "0.26", features = ["derive"] }
 aws-config = "1.5.5"
 aws-sdk-kms = "1.40.0"
 
+ethereum-types = {version = "0.15.1"}
 [features]
 default = ["mock"]
 mock = ["yubihsm/mockhsm"]

--- a/src/signers/aws_kms.rs
+++ b/src/signers/aws_kms.rs
@@ -143,7 +143,7 @@ pub async fn handle_eth_sign_jsonrpc(
         "health_status" => handle_health_status(payload).await,
         "opsigner_signBlockPayload" => handle_eth_sign_block(payload, signer).await,
         _ => Err(anyhow!(
-            "method not supported (only eth_signTransaction and health_status): {}",
+            "method not supported (only eth_signTransaction, health_status and opsigner_signBlockPayload): {}",
             method
         )),
     };
@@ -178,8 +178,6 @@ pub async fn handle_eth_sign_block(
     // encode as a "0x"-prefixed hex string
     let signed_hash_hex = hex::encode_prefixed(&sig_bytes[..]);
     
-    // Build JSON-RPC reply
-    // let result = Value::String(sig_hex);
     Ok(JsonRpcReply {
         id: payload.id,
         jsonrpc: payload.jsonrpc,

--- a/src/signers/aws_kms.rs
+++ b/src/signers/aws_kms.rs
@@ -168,6 +168,7 @@ pub async fn handle_eth_sign_block(
     let block_object = params[0].clone();
     let block: BlockPayloadArgs = serde_json::from_value(block_object)?;
 
+    println!("block: {:?}", block);
     let signing_hash = to_signing_hash(&block);
 
     let signed_hash  = signer.sign_hash(&signing_hash).await?;

--- a/src/signers/common.rs
+++ b/src/signers/common.rs
@@ -3,7 +3,7 @@ use alloy::{
     hex,
     network::{EthereumWallet, TransactionBuilder},
     rpc::types::TransactionRequest,
-    primitives::{U256, Address, B256, keccak256},
+    primitives::{U256, B256, keccak256},
 };
 
 use anyhow::{anyhow, Result as AnyhowResult};
@@ -24,7 +24,6 @@ pub struct BlockPayloadArgs {
 
     #[serde(with = "hex::serde")]
     pub payload_hash: [u8; 32], // 32 bytes
-    pub sender_address: Address, // 20 bytes, handles 0x-prefixed hex
 }
 
 

--- a/src/signers/mock.rs
+++ b/src/signers/mock.rs
@@ -1,6 +1,6 @@
 use crate::signers::yubihsm::AppState;
 use alloy::primitives::hex;
-use alloy::{network::EthereumWallet, signers::local::yubihsm::Domain, signers::local::YubiSigner};
+use alloy::{signers::local::yubihsm::Domain, signers::local::YubiSigner};
 use anyhow::Result as AnyhowResult;
 
 use std::sync::Arc;
@@ -34,17 +34,19 @@ pub async fn add_mock_signers(
     };
 
     for (key_id, private_key, _address) in keys_to_use {
-        let yubi_signer = YubiSigner::from_key(
-            state.connector.clone(),
-            state.credentials.clone(),
-            key_id,
-            "".into(),
-            Domain::all(),
-            private_key,
-        )?;
-        let eth_signer = EthereumWallet::from(yubi_signer);
+        let yubi_signer = 
+        Arc::new(
+            YubiSigner::from_key(
+                state.connector.clone(),
+                state.credentials.clone(),
+                key_id,
+                "".into(),
+                Domain::all(),
+                private_key,
+            )?
+        );
 
-        signers.insert(key_id, eth_signer.clone());
+        signers.insert(key_id, yubi_signer.clone());
     }
 
     Ok(())

--- a/src/signers/yubihsm.rs
+++ b/src/signers/yubihsm.rs
@@ -39,7 +39,7 @@ use crate::{
 
 };
 use alloy::primitives::{Address};
-use::alloy::hex;
+use alloy::hex;
 
 
 const DEFAULT_USB_TIMEOUT_MS: u64 = 30_000;
@@ -285,7 +285,7 @@ pub async fn handle_eth_sign_jsonrpc(
         "health_status" => handle_health_status(payload).await,
         "opsigner_signBlockPayload" => handle_eth_sign_block(payload, signer).await,
         _ => Err(anyhow!(
-            "method not supported (only eth_signTransaction and health_status): {}",
+            "method not supported (only eth_signTransaction, health_status and opsigner_signBlockPayload): {}",
             method
         )),
     };

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.7.4",
+    "axios": "^1.7.5",
     "readline-sync": "^1.4.10",
     "viem": "^2.20.0"
   }


### PR DESCRIPTION
The proxy now handles `opsigner_signBlockPayload`, which is used by the sequencer to sign blocks.

For both AWS KMS and YubiHSM:
- Deserializes the requests payload
- Constructs the relelvant data which it takes a hash of
- Signs the hash and returns it

