### PR TITLE
sign-block-fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ alloy = { git = "https://github.com/upnode-org/alloy", features = [
   "network",
   "signer-yubihsm",
   "signer-aws",
+  "signers",
+  "signer-local",
 ] }
 yubihsm = { version = "0.42.1", features = ["secp256k1", "http", "usb"] }
 anyhow = "1.0.86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 structopt = "0.3"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-alloy = { git = "https://github.com/quertc/alloy", branch = "better-yubi", features = [
+alloy = { git = "https://github.com/upnode-org/alloy", features = [
   "rlp",
   "rpc-types",
   "eips",

--- a/src/signers/aws_kms.rs
+++ b/src/signers/aws_kms.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use alloy::network::EthereumWallet;
-use anyhow::{anyhow, Result as AnyhowResult};
-use alloy::signers::{aws::AwsSigner, Signer};
+use anyhow::{Result as AnyhowResult};
+use alloy::{
+    primitives::{Address},
+    signers::{aws::AwsSigner, Signer},
+};
 use aws_config::BehaviorVersion;
 use aws_sdk_kms::Client;
 use axum::http::StatusCode;
@@ -23,13 +25,11 @@ use tracing::info;
 
 use crate::jsonrpc::AddressResponse;
 use crate::{
-    app_types::{AppError, AppJson, AppResult},
-    jsonrpc::{JsonRpcReply, JsonRpcRequest, JsonRpcResult},
+    app_types::{AppJson, AppResult},
+    jsonrpc::{JsonRpcReply, JsonRpcRequest},
     shutdown_signal::shutdown_signal,
-    signers::common::{handle_eth_sign_transaction, handle_health_status, to_signing_hash, BlockPayloadArgs},
+    signers::common::{handle_eth_sign_jsonrpc},
 };
-use::alloy::hex;
-use alloy::primitives::{Address};
 
 
 #[derive(StructOpt)]
@@ -46,7 +46,7 @@ pub enum AwsCommand {
 #[derive(Clone)]
 struct AppState {
     client: Client,
-    signers: Arc<Mutex<HashMap<String, AwsSigner>>>,
+    signers: Arc<Mutex<HashMap<String, Arc<AwsSigner>>>>,
 }
 
 const API_TIMEOUT_SECS: u64 = 30;
@@ -66,14 +66,14 @@ async fn handle_request(
     handle_eth_sign_jsonrpc(payload, signer).await
 }
 
-async fn get_signer(state: Arc<AppState>, key_id: String) -> AnyhowResult<AwsSigner> {
+async fn get_signer(state: Arc<AppState>, key_id: String) -> AnyhowResult<Arc<AwsSigner>> {
     let mut signers = state.signers.lock().await;
 
     if let Some(signer) = signers.get(&key_id) {
         return Ok(signer.clone());
     }
 
-    let signer = AwsSigner::new(state.client.clone(), key_id.clone(), None).await?;
+    let signer = Arc::new(AwsSigner::new(state.client.clone(), key_id.clone(), None).await?);
     signers.insert(key_id.clone(), signer.clone());
     Ok(signer)
 }
@@ -132,64 +132,6 @@ pub async fn handle_aws_kms(opt: AwsOpt) {
 }
 
 
-pub async fn handle_eth_sign_jsonrpc(
-    payload: JsonRpcRequest<Vec<Value>>,
-    signer: AwsSigner,
-) -> AppResult<JsonRpcReply<Value>> {
-    let method = payload.method.as_str();
-
-    let result = match method {
-        "eth_signTransaction" => handle_eth_sign_transaction(payload, EthereumWallet::from(signer)).await,
-        "health_status" => handle_health_status(payload).await,
-        "opsigner_signBlockPayload" => handle_eth_sign_block(payload, signer).await,
-        _ => Err(anyhow!(
-            "method not supported (only eth_signTransaction, health_status and opsigner_signBlockPayload): {}",
-            method
-        )),
-    };
-
-    result.map(AppJson).map_err(AppError)
-}
-
-
-
-
-pub async fn handle_eth_sign_block(
-    payload: JsonRpcRequest<Vec<Value>>,
-    signer: AwsSigner,
-) -> AnyhowResult<JsonRpcReply<Value>> {
-
-    println!("handle_eth_sign_block payload: {:?}", payload);
-    let params = payload.params.ok_or_else(|| anyhow!("params is empty"))?;
-    if params.is_empty() {
-        return Err(anyhow!("params is empty"));
-    }
-
-    let block_object = params[0].clone();
-    let block: BlockPayloadArgs = serde_json::from_value(block_object)?;
-
-    println!("block: {:?}", block);
-    let signing_hash = to_signing_hash(&block);
-
-    let signed_hash  = signer.sign_hash(&signing_hash).await?;
-
-    // extract the 65-byte array
-    let mut sig_bytes: [u8; 65] = signed_hash.as_bytes();
-    if sig_bytes[64] < 27 {
-        return Err(anyhow!("Invalid recovery id: expected value >= 27, got {}", sig_bytes[64]));
-    }
-
-    sig_bytes[64] = sig_bytes[64] - 27; // Adjust the recovery id to be 0 or 1
-
-    // encode as a "0x"-prefixed hex string
-    let signed_hash_hex = hex::encode_prefixed(&sig_bytes[..]);
-    println!("signed_hash_hex: {:?}", signed_hash_hex);
-    Ok(JsonRpcReply {
-        id: payload.id,
-        jsonrpc: payload.jsonrpc,
-        result: JsonRpcResult::Result(Value::String(signed_hash_hex)),
-    })
-}
 
 
 

--- a/src/signers/aws_kms.rs
+++ b/src/signers/aws_kms.rs
@@ -174,11 +174,16 @@ pub async fn handle_eth_sign_block(
     let signed_hash  = signer.sign_hash(&signing_hash).await?;
 
     // extract the 65-byte array
-    let sig_bytes: [u8; 65] = signed_hash.as_bytes();
+    let mut sig_bytes: [u8; 65] = signed_hash.as_bytes();
+    if sig_bytes[64] < 27 {
+        return Err(anyhow!("Invalid recovery id: expected value >= 27, got {}", sig_bytes[64]));
+    }
+
+    sig_bytes[64] = sig_bytes[64] - 27; // Adjust the recovery id to be 0 or 1
 
     // encode as a "0x"-prefixed hex string
     let signed_hash_hex = hex::encode_prefixed(&sig_bytes[..]);
-    
+    println!("signed_hash_hex: {:?}", signed_hash_hex);
     Ok(JsonRpcReply {
         id: payload.id,
         jsonrpc: payload.jsonrpc,

--- a/src/signers/common.rs
+++ b/src/signers/common.rs
@@ -1,15 +1,20 @@
 use alloy::{
     eips::eip2718::Encodable2718,
     hex,
-    network::{EthereumWallet, TransactionBuilder},
+    //rpc::types::TransactionRequest,
+    primitives::{U256, B256, keccak256, Address, Signature},
+    network::{TxSigner, EthereumWallet, TransactionBuilder},
+    signers::{Signer},
     rpc::types::TransactionRequest,
-    primitives::{U256, B256, keccak256, Address},
+
 };
+use std::{sync::Arc};
 
 use anyhow::{anyhow, Result as AnyhowResult};
 use serde_json::Value;
 
 use crate::{
+    app_types::{AppError, AppJson, AppResult},
     jsonrpc::{JsonRpcReply, JsonRpcRequest, JsonRpcResult},
 };
 
@@ -68,14 +73,78 @@ pub async fn handle_health_status(
 }
 
 
+pub async fn handle_eth_sign_jsonrpc<S>(
+    payload: JsonRpcRequest<Vec<Value>>,
+    signer: Arc<S>,
+) -> AppResult<JsonRpcReply<Value>> 
+where S: Signer + std::marker::Sync + std::marker::Send + TxSigner<Signature> + 'static
+
+{
+    let method = payload.method.as_str();
+
+    let result = match method {
+        "eth_signTransaction" => handle_eth_sign_transaction(payload, EthereumWallet::from(signer)).await,
+        "health_status" => handle_health_status(payload).await,
+        "opsigner_signBlockPayload" => handle_eth_sign_block(payload, signer).await,
+        _ => Err(anyhow!(
+            "method not supported (only eth_signTransaction, health_status and opsigner_signBlockPayload): {}",
+            method
+        )),
+    };
+
+    result.map(AppJson).map_err(AppError)
+}
+
+
+
+pub async fn handle_eth_sign_block<S>(
+    payload: JsonRpcRequest<Vec<Value>>,
+    signer: Arc<S>,
+) -> AnyhowResult<JsonRpcReply<Value>> 
+where S: Signer
+{
+
+    println!("handle_eth_sign_block payload: {:?}", payload);
+    let params = payload.params.ok_or_else(|| anyhow!("params is empty"))?;
+    if params.is_empty() {
+        return Err(anyhow!("params is empty"));
+    }
+
+    let block_object = params[0].clone();
+    let block: BlockPayloadArgs = serde_json::from_value(block_object)?;
+
+    println!("block: {:?}", block);
+    let signing_hash = to_signing_hash(&block);
+
+    let signed_hash  = signer.sign_hash(&signing_hash).await?;
+
+    // extract the 65-byte array
+    let mut sig_bytes: [u8; 65] = signed_hash.as_bytes();
+    if sig_bytes[64] < 27 {
+        return Err(anyhow!("Invalid recovery id: expected value >= 27, got {}", sig_bytes[64]));
+    }
+
+    sig_bytes[64] = sig_bytes[64] - 27; // Adjust the recovery id to be 0 or 1
+
+    // encode as a "0x"-prefixed hex string
+    let signed_hash_hex = hex::encode_prefixed(&sig_bytes[..]);
+    println!("signed_hash_hex: {:?}", signed_hash_hex);
+    Ok(JsonRpcReply {
+        id: payload.id,
+        jsonrpc: payload.jsonrpc,
+        result: JsonRpcResult::Result(Value::String(signed_hash_hex)),
+    })
+}
+
 
 pub fn to_signing_hash(args: &BlockPayloadArgs) -> B256 {
+    // hash the block to be signed
     let mut msg_input = [0u8; 96];
     msg_input[0..32].copy_from_slice(&args.domain);
 
     // Convert U256 → B256 (i.e. big-endian bytes) then grab the inner [u8;32]
     let chain_id_bytes: [u8; 32] = B256::from(args.chain_id).0; 
-    msg_input[32..64].copy_from_slice(&chain_id_bytes);  //  [oai_citation_attribution:0‡Docs.rs](https://docs.rs/alloy-primitives/latest/alloy_primitives/aliases/type.B256.html)
+    msg_input[32..64].copy_from_slice(&chain_id_bytes); 
 
     let payload_hash_bytes: [u8; 32] = args
     .payload_hash

--- a/src/signers/yubihsm.rs
+++ b/src/signers/yubihsm.rs
@@ -1,11 +1,9 @@
-use anyhow::{anyhow, Result as AnyhowResult};
+use anyhow::{Result as AnyhowResult};
 use crate::shutdown_signal::shutdown_signal;
 #[cfg(debug_assertions)]
 use crate::signers::mock::{add_mock_signers, MOCK_KEYS};
 use alloy::{
-    network::EthereumWallet,
     signers::{
-        Signer,
         local::{
         yubihsm::{
             asymmetric::Algorithm::EcK256, device::SerialNumber, Capability, Client, Connector,
@@ -13,7 +11,7 @@ use alloy::{
         },
         YubiSigner,
         },
-    },
+    }, 
 };
 use axum::routing::get;
 use axum::{
@@ -33,13 +31,12 @@ use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 use tracing::info;
 use crate::{
-    app_types::{AppError, AppJson, AppResult},
-    jsonrpc::{JsonRpcReply, JsonRpcRequest, JsonRpcResult, AddressResponse},
-    signers::common::{handle_eth_sign_transaction, handle_health_status, to_signing_hash, BlockPayloadArgs},
+    app_types::{AppJson, AppResult},
+    jsonrpc::{JsonRpcReply, JsonRpcRequest, AddressResponse},
+    signers::common::{handle_eth_sign_jsonrpc},
 
 };
 use alloy::primitives::{Address};
-use alloy::hex;
 
 
 const DEFAULT_USB_TIMEOUT_MS: u64 = 30_000;
@@ -130,8 +127,8 @@ async fn handle_request(
     AppJson(payload): AppJson<JsonRpcRequest<Vec<Value>>>,
 ) -> AppResult<JsonRpcReply<Value>> {
     println!("{:?}", payload);
-    let eth_signer = get_signer(state.clone(), key_id).await?;
-    handle_eth_sign_jsonrpc(payload, eth_signer).await
+    let yubi_signer = get_signer(state.clone(), key_id).await?;
+    handle_eth_sign_jsonrpc(payload, yubi_signer).await
 }
 
 async fn get_signer(state: Arc<AppState>, key_id: u16) -> AnyhowResult<Arc<YubiSigner>> {
@@ -157,8 +154,8 @@ async fn handle_address_request(
     Path(key_id): Path<u16>,
     State(state): State<Arc<AppState>>,
 ) -> AppResult<AddressResponse> {
-    let eth_signer = get_signer(state.clone(), key_id).await?;
-    let address = eth_signer.address().to_string();
+    let yubi_signer = get_signer(state.clone(), key_id).await?;
+    let address = yubi_signer.address().to_string();
 
     Ok(AppJson(AddressResponse { address }))
 }
@@ -274,60 +271,4 @@ pub async fn handle_yubihsm(opt: YubiOpt) {
     }
 }
 
-pub async fn handle_eth_sign_jsonrpc(
-    payload: JsonRpcRequest<Vec<Value>>,
-    signer: Arc<YubiSigner>,
-) -> AppResult<JsonRpcReply<Value>> {
-    let method = payload.method.as_str();
-
-    let result = match method {
-        "eth_signTransaction" => handle_eth_sign_transaction(payload, EthereumWallet::from(signer)).await,
-        "health_status" => handle_health_status(payload).await,
-        "opsigner_signBlockPayload" => handle_eth_sign_block(payload, signer).await,
-        _ => Err(anyhow!(
-            "method not supported (only eth_signTransaction, health_status and opsigner_signBlockPayload): {}",
-            method
-        )),
-    };
-
-    result.map(AppJson).map_err(AppError)
-}
-
-
-pub async fn handle_eth_sign_block(
-    payload: JsonRpcRequest<Vec<Value>>,
-    signer: Arc<YubiSigner>,
-) -> AnyhowResult<JsonRpcReply<Value>> {
-
-    let params = payload.params.ok_or_else(|| anyhow!("params is empty"))?;
-    if params.is_empty() {
-        return Err(anyhow!("params is empty"));
-    }
-
-    let block_object = params[0].clone();
-    let block: BlockPayloadArgs = serde_json::from_value(block_object)?;
-
-    println!("block: {:?}", block);
-    let signing_hash = to_signing_hash(&block);
-
-    let signed_hash  = signer.sign_hash(&signing_hash).await?;
-
-    // extract the 65-byte array
-    let mut sig_bytes: [u8; 65] = signed_hash.as_bytes();
-    if sig_bytes[64] < 27 {
-        return Err(anyhow!("Invalid recovery id: expected value >= 27, got {}", sig_bytes[64]));
-    }
-
-    sig_bytes[64] = sig_bytes[64] - 27; // Adjust the recovery id to be 0 or 1
-
-    // encode as a "0x"-prefixed hex string
-    let signed_hash_hex = hex::encode_prefixed(&sig_bytes[..]);
-    println!("signed_hash_hex: {:?}", signed_hash_hex);
-    // Build JSON-RPC reply
-    Ok(JsonRpcReply {
-        id: payload.id,
-        jsonrpc: payload.jsonrpc,
-        result: JsonRpcResult::Result(Value::String(signed_hash_hex)),
-    })
-}
 


### PR DESCRIPTION
- updated alloy crate
- fixed the recovery byte V, from R,S,V signature (op-geth expects values between 0 and 1, yet the signer returns values 27 and 28. I handle this by subtracting 27)
- refactored block signing and request handling to be common instead of seperate implementations for YubiHMS and AWS KMS